### PR TITLE
Breadcrumb

### DIFF
--- a/src/components/molecules/breadcrumb.tsx
+++ b/src/components/molecules/breadcrumb.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { NextPage } from 'next'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import styled from 'styled-components'
 
 type Props = {
   pageTitle: string
@@ -13,29 +14,56 @@ const BreadCrumb: NextPage<Props> = ({ pageTitle }) => {
   let currentPath = ''
 
   return (
-    <div>
-      <Link href={'/'}>トップページ</Link>
-      {paths.map((x, i) => {
-        currentPath += '/' + x
-        return (
-          <React.Fragment key={i}>
-            {'>'}
-            {i === paths.length - 1 ? (
-              x === 'blogs' ? (
-                <span>ブログ</span>
+    <nav aria-label="現在位置">
+      <BreadcrumbList>
+        <li>
+          <Link href={'/'}>トップページ</Link>
+        </li>
+        {paths.map((x, i) => {
+          currentPath += '/' + x
+          return (
+            <React.Fragment key={i}>
+              {i === paths.length - 1 ? (
+                x === 'blogs' ? (
+                  <li>
+                    <a aria-current="page">全ての記事</a>
+                  </li>
+                ) : (
+                  <li aria-current="page">
+                    <a aria-current="page">{pageTitle}</a>
+                  </li>
+                )
               ) : (
-                <span>{pageTitle}</span>
-              )
-            ) : (
-              <Link href={currentPath} key={i}>
-                {x === 'blogs' ? 'ブログ' : x}
-              </Link>
-            )}
-          </React.Fragment>
-        )
-      })}
-    </div>
+                <li>
+                  <Link href={currentPath} key={i}>
+                    {x === 'blogs' ? '全ての記事' : x}
+                  </Link>
+                </li>
+              )}
+            </React.Fragment>
+          )
+        })}
+      </BreadcrumbList>
+    </nav>
   )
 }
+
+const BreadcrumbList = styled.ol`
+  display: flex;
+  flex-wrap: wrap;
+  li:not(:first-child)::before {
+    content: '';
+    display: inline-block;
+    width: 0.5rem;
+    height: 0.5rem;
+    margin: 0.1rem 0.5rem 0.1rem 0;
+    border-top: 1px solid #000;
+    border-right: 1px solid #000;
+    transform: rotate(45deg);
+  }
+  a {
+    margin-right: 0.5rem;
+  }
+`
 
 export default BreadCrumb

--- a/src/components/molecules/breadcrumb.tsx
+++ b/src/components/molecules/breadcrumb.tsx
@@ -21,10 +21,14 @@ const BreadCrumb: NextPage<Props> = ({ pageTitle }) => {
           <React.Fragment key={i}>
             {'>'}
             {i === paths.length - 1 ? (
-              <span>{pageTitle}</span>
+              x === 'blogs' ? (
+                <span>ブログ</span>
+              ) : (
+                <span>{pageTitle}</span>
+              )
             ) : (
               <Link href={currentPath} key={i}>
-                {x}
+                {x === 'blogs' ? 'ブログ' : x}
               </Link>
             )}
           </React.Fragment>

--- a/src/components/molecules/breadcrumb.tsx
+++ b/src/components/molecules/breadcrumb.tsx
@@ -1,41 +1,37 @@
 import React from 'react'
-import styled from 'styled-components'
+import { NextPage } from 'next'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
 
-type ListItem = {
-  string: string
-  path: string
+type Props = {
+  pageTitle: string
 }
 
-type BreadCrumbsProps = {
-  lists: ListItem[] | null | undefined
-}
-
-const BreadCrumbs: React.FC<BreadCrumbsProps> = ({ lists }) => {
-  if (!lists) {
-    return null // リストが存在しない場合、null を返す
-  }
+const BreadCrumb: NextPage<Props> = ({ pageTitle }) => {
+  const router = useRouter()
+  const paths = decodeURI(router.asPath).substring(1).split('/')
+  let currentPath = ''
 
   return (
-    <BreadCrumbsList aria-label="現在地の階層">
-      {lists.map(({ string, path }, index) => (
-        <li key={index}>
-          {lists.length - 1 !== index ? (
-            <>
-              <a href={path}>{string}</a>
-              {'/'}
-            </>
-          ) : (
-            <span aria-current="page">{string}</span>
-          )}
-        </li>
-      ))}
-    </BreadCrumbsList>
+    <div>
+      <Link href={'/'}>トップページ</Link>
+      {paths.map((x, i) => {
+        currentPath += '/' + x
+        return (
+          <React.Fragment key={i}>
+            {'>'}
+            {i === paths.length - 1 ? (
+              <span>{pageTitle}</span>
+            ) : (
+              <Link href={currentPath} key={i}>
+                {x}
+              </Link>
+            )}
+          </React.Fragment>
+        )
+      })}
+    </div>
   )
 }
 
-const BreadCrumbsList = styled.ol`
-  display: flex;
-  font-size: 0.875rem;
-`
-
-export default BreadCrumbs
+export default BreadCrumb

--- a/src/pages/blogs/[id].tsx
+++ b/src/pages/blogs/[id].tsx
@@ -7,7 +7,9 @@ import { client } from '@/lib/client'
 import Image from 'next/image'
 import Button from '@/components/atoms/button'
 import Link from 'next/link'
-import BreadCrumbs from '@/components/molecules/breadcrumb'
+
+//パンクズ
+import BreadCrumb from '@/components/molecules/breadcrumb'
 
 type Props = {
   data: {
@@ -37,23 +39,13 @@ type Props = {
 const BlogDetail: NextPageWithLayout<Props> = (props) => {
   const { title, content, eyecatch } = props.data
   const { prevPost, nextPost } = props
+  // const pageTitle = title
 
   return (
     <>
       <NextSeo title={`${title} | あべのサイト`} />
       <BlogPage>
-        <BreadCrumbs
-          lists={[
-            {
-              string: 'トップページ',
-              path: '/',
-            },
-            {
-              string: title, // タイトルを表示する
-              path: '', // path プロパティを追加し、空文字列を指定
-            },
-          ]}
-        />
+        <BreadCrumb pageTitle={title} />
         <BlogTitle>{title}</BlogTitle>
         {eyecatch && (
           <Image

--- a/src/pages/blogs/index.tsx
+++ b/src/pages/blogs/index.tsx
@@ -4,7 +4,7 @@ import { client } from '@/lib/client'
 import DefaultLayout from '@/components/layout/default-layout'
 import Link from 'next/link'
 import Button from '@/components/atoms/button'
-import BreadCrumbs from '@/components/molecules/breadcrumb'
+import BreadCrumb from '@/components/molecules/breadcrumb'
 import { NextSeo } from 'next-seo'
 import styled from 'styled-components'
 
@@ -23,18 +23,7 @@ const AllBlogs: NextPageWithLayout<Props> = ({ allBlogs, pageTitle }) => {
   return (
     <>
       <NextSeo title={pageTitle} /> {/* pageTitleを使用 */}
-      <BreadCrumbs
-        lists={[
-          {
-            string: 'トップページ',
-            path: '/',
-          },
-          {
-            string: pageTitle, // タイトルを表示する
-            path: '', // path プロパティを追加し、空文字列を指定
-          },
-        ]}
-      />
+      <BreadCrumb pageTitle={pageTitle} />
       <PageTitle>{pageTitle}</PageTitle>
       <AllBlogList>
         <ul>
@@ -73,7 +62,7 @@ const PageTitle = styled.h1`
 `
 
 const AllBlogList = styled.div`
-  margin-top: 1rem;
+  margin-top: 2rem;
 `
 
 const ButtonWrapper = styled.div`

--- a/src/pages/blogs/index.tsx
+++ b/src/pages/blogs/index.tsx
@@ -50,7 +50,7 @@ export const getStaticProps: GetStaticProps = async () => {
   return {
     props: {
       allBlogs: allBlogs.contents,
-      pageTitle: '記事一覧', // pageTitleを適切な値に設定
+      pageTitle: '全ての記事', // pageTitleを適切な値に設定
     },
   }
 }


### PR DESCRIPTION
パンクズリストの調整

・デザイン調整
・取得方法変更
・トップページから現在のページの間の階層である「全ての記事」を表示